### PR TITLE
Speed up and fix pkgbase

### DIFF
--- a/build-aur-action/entrypoint.sh
+++ b/build-aur-action/entrypoint.sh
@@ -6,19 +6,18 @@ useradd builder -m
 echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 chmod -R a+rw .
 
+cat << EOM >> /etc/pacman.conf
+[archlinuxcn]
+Server = https://repo.archlinuxcn.org/x86_64
+EOM
+
 pacman-key --init
+pacman-key --lsign-key "farseerfc@archlinux.org"
+pacman -Sy --noconfirm && pacman -S --noconfirm archlinuxcn-keyring
 pacman -Syu --noconfirm archlinux-keyring
-install-yay(){
-  pacman -S --needed --noconfirm base-devel
-  sudo --set-home -u builder git clone https://aur.archlinux.org/yay-bin.git buildyay
-  cd buildyay
-  sudo --set-home -u builder makepkg -si --noconfirm
-  cd ..
-  rm -rf buildyay
-}
-install-yay
+pacman -S --noconfirm yay
 if [ ! -z "$INPUT_PREINSTALLPKGS" ]; then
-    pacman -Su --noconfirm "$INPUT_PREINSTALLPKGS"
+    pacman -S --noconfirm "$INPUT_PREINSTALLPKGS"
 fi
 
 sudo --set-home -u builder yay -S --noconfirm --builddir=./ "$pkgname"

--- a/build-aur-action/entrypoint.sh
+++ b/build-aur-action/entrypoint.sh
@@ -6,20 +6,44 @@ useradd builder -m
 echo "builder ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 chmod -R a+rw .
 
-cat << EOM >> /etc/pacman.conf
-[archlinuxcn]
-Server = https://repo.archlinuxcn.org/x86_64
-EOM
-
 pacman-key --init
-pacman-key --lsign-key "farseerfc@archlinux.org"
-pacman -Sy --noconfirm && pacman -S --noconfirm archlinuxcn-keyring
 pacman -Syu --noconfirm archlinux-keyring
-pacman -Syu --noconfirm yay
+install-yay(){
+  pacman -S --needed --noconfirm base-devel
+  sudo --set-home -u builder git clone https://aur.archlinux.org/yay-bin.git buildyay
+  cd buildyay
+  sudo --set-home -u builder makepkg -si --noconfirm
+  cd ..
+  rm -rf buildyay
+}
+install-yay
 if [ ! -z "$INPUT_PREINSTALLPKGS" ]; then
-    pacman -Syu --noconfirm "$INPUT_PREINSTALLPKGS"
+    pacman -Su --noconfirm "$INPUT_PREINSTALLPKGS"
 fi
 
 sudo --set-home -u builder yay -S --noconfirm --builddir=./ "$pkgname"
-cd "./$pkgname" || exit 1
+
+# Find the actual build directory (pkgbase) created by yay.
+# Some AUR packages use a different pkgbase directory name,
+# e.g. otf-space-grotesk has a pkgbase 38c3-styles, 
+# when using yay -S otf-space-grotesk, it's built under folder 38c3-styles.
+function get_pkgbase(){
+  local pkg="$1"
+  url="https://aur.archlinux.org/rpc/?v=5&type=info&arg=${pkg}"
+  resp="$(curl -sS "$url")"
+  pkgbase="$(printf '%s' "$resp" | jq -r '.results[0].PackageBase // .results[0].Name')"
+  echo "$pkgbase"
+}
+
+if [[ -d "$pkgname" ]];
+  then
+    pkgdir="$pkgname"
+  else
+    pacman -S --needed --noconfirm jq
+    pkgdir="$(get_pkgbase $pkgname)"
+fi
+
+echo "The pkgdir is $pkgdir"
+echo "The pkgname is $pkgname"
+cd $pkgdir || exit 1
 python3 ../build-aur-action/encode_name.py


### PR DESCRIPTION
通过使用 `yay-bin` 避免添加 ArchLinuxCN，以及去掉多余的 `-y` 来减少浪费时间（我测试下来省了20秒）；
（`-y` 用来联网刷新软件仓库数据，除非有必要，否则刷新一次就够了，多余的刷新不仅浪费时间也给服务器增加不必要的网络负担。）

通过获取 pkgbase，修复了当 pkgbase 与 pkgname 不一致时 `entrypoint.sh` 中 `cd $pkgname` 提示目录不存在的错误。